### PR TITLE
Log response body for whitelisted content types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 /doc
 /pkg
 /rdoc
+.ruby-version
+.ruby-gemset
+.rvmrc

--- a/lib/restclient.rb
+++ b/lib/restclient.rb
@@ -104,6 +104,11 @@ module RestClient
     @@log_verbosity = verbosity
   end
 
+  def self.log_response_body_for_content_types= content_types
+    content_types = [content_types]  if content_types.is_a?(String)
+    @@log_response_body_for_content_types = content_types
+  end
+
   # Create a log that respond to << like a logger
   # param can be 'stdout', 'stderr', a string (then we will log to that file) or a logger (then we return it)
   def self.create_log param
@@ -145,6 +150,7 @@ module RestClient
 
   @@log = nil
   @@log_verbosity = :default
+  @@log_response_body_for_content_types = []
 
   def self.log # :nodoc:
     @@env_log || @@log
@@ -152,6 +158,10 @@ module RestClient
 
   def self.log_verbosity
     @@log_verbosity
+  end
+
+  def self.log_response_body_for_content_types
+    @@log_response_body_for_content_types
   end
 
   @@before_execution_procs = []

--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -534,8 +534,12 @@ module RestClient
                res.body.nil? ? 0 : res.body.size
              end
 
-      RestClient.log << "# => #{res.code} #{res.class.to_s.gsub(/^Net::HTTP/, '')} | #{(res['Content-type'] || '').gsub(/;.*$/, '')} #{size} bytes\n"
-      RestClient.log << "# => #{res.body || 'nil'}"  if RestClient.log_verbosity == :verbose
+      readable_status = res.class.to_s.gsub(/^Net::HTTP/, '')
+      content_type_without_charset = (res['Content-type'] || '').gsub(/;.*$/, '')
+      RestClient.log << "# => #{res.code} #{readable_status} | #{content_type_without_charset} #{size} bytes\n"
+      if RestClient.log_verbosity == :verbose || RestClient.log_response_body_for_content_types.include?(content_type_without_charset)
+        RestClient.log << "# => #{res.body || 'nil'}"
+      end
     end
 
     # Return a hash of headers whose keys are capitalized strings

--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -415,6 +415,28 @@ describe RestClient::Request do
       log[0].should eq "# => 200 OK | text/html 0 bytes\n"
     end
 
+    context "log_response_body_for_content_types is set to ['application/json', 'text/plain']" do
+      before(:each) { RestClient.log_response_body_for_content_types = ['application/json', 'text/plain'] }
+      let!(:log) { RestClient.log = [] }
+
+      it "logs a response with Content-Type=application/json" do
+        res = double('result', :code => '200', :class => Net::HTTPOK, :body => %Q{{"some": "json"}})
+        res.stub(:[]).with('Content-type').and_return('application/json; charset=utf-8')
+        @request.log_response res
+        log.size.should eq 2
+        log[0].should eq "# => 200 OK | application/json 16 bytes\n"
+        log[1].should eq %Q{# => {"some": "json"}}
+      end
+
+      it "does not log a response with Content-Type=text/html" do
+        res = double('result', :code => '200', :class => Net::HTTPOK, :body => nil)
+        res.stub(:[]).with('Content-type').and_return('text/html; charset=utf-8')
+        @request.log_response res
+        log.size.should eq 1
+        log[0].should eq "# => 200 OK | text/html 0 bytes\n"
+      end
+    end
+
     context "log_verbosity is set to :verbose" do
       before(:each) { RestClient.log_verbosity = :verbose }
       let!(:log) { RestClient.log = [] }


### PR DESCRIPTION
fixes https://github.com/wealthsimple/issues/issues/685 by giving us the ability to specify which content-types we want to log the response body.

Example usage:

``` ruby
# /config/initializers/rest-client.rb
RestClient.log_response_body_for_content_types = [
  'application/json',
  'application/xml',
  'text/plain',
  'text/html',
]
```
