### PR TITLE
Don't log encrypted responses

### DIFF
--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -538,7 +538,11 @@ module RestClient
       content_type_without_charset = (res['Content-type'] || '').gsub(/;.*$/, '')
       RestClient.log << "# => #{res.code} #{readable_status} | #{content_type_without_charset} #{size} bytes\n"
       if RestClient.log_verbosity == :verbose || RestClient.log_response_body_for_content_types.include?(content_type_without_charset)
-        RestClient.log << "# => #{res.body || 'nil'}"
+        if res['Authorization'] && res['Authorization'].match(/\Aapiauth\s/i)
+          RestClient.log << "# => <encrypted>"
+        else
+          RestClient.log << "# => #{res.body || 'nil'}"
+        end
       end
     end
 

--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -439,6 +439,7 @@ describe RestClient::Request do
 
     context "log_verbosity is set to :verbose" do
       before(:each) { RestClient.log_verbosity = :verbose }
+      after(:each) { RestClient.log_verbosity = nil }
       let!(:log) { RestClient.log = [] }
 
       it "logs a response with a body" do


### PR DESCRIPTION
encrypted responses like `���` should not be logged since they provide little value and end up causing extra noise in our logs.
