### PR TITLE
Merges v1.8.0 from the official version

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+machine:
+  ruby:
+    version: 2.3.0

--- a/history.md
+++ b/history.md
@@ -1,3 +1,9 @@
+# 1.7.3
+
+- Security: redact password in URI from logs (#349 / OSVDB-117461)
+- Drop monkey patch on MIME::Types (added `type_for_extension` method, use
+  the public interface instead.
+
 # 1.7.2
 
 - Ignore duplicate certificates in CA store on Windows

--- a/history.md
+++ b/history.md
@@ -1,3 +1,15 @@
+# 1.8.0
+
+- Security: implement standards compliant cookie handling by adding a
+  dependency on http-cookie. This breaks compatibility, but was necessary to
+  address a session fixation / cookie disclosure vulnerability.
+  (#369 / CVE-2015-1820)
+
+  Previously, any Set-Cookie headers found in an HTTP 30x response would be
+  sent to the redirection target, regardless of domain. Responses now expose a
+  cookie jar and respect standards compliant domain / path flags in Set-Cookie
+  headers.
+
 # 1.7.3
 
 - Security: redact password in URI from logs (#349 / OSVDB-117461)

--- a/lib/restclient/abstract_response.rb
+++ b/lib/restclient/abstract_response.rb
@@ -5,7 +5,7 @@ module RestClient
 
   module AbstractResponse
 
-    attr_reader :net_http_res, :args
+    attr_reader :net_http_res, :args, :request
 
     # HTTP status code
     def code
@@ -23,11 +23,17 @@ module RestClient
       @raw_headers ||= @net_http_res.to_hash
     end
 
+    def response_set_vars(net_http_res, args, request)
+      @net_http_res = net_http_res
+      @args = args
+      @request = request
+    end
+
     # Hash of cookies extracted from response headers
     def cookies
       hash = {}
 
-      cookie_jar.cookies.each do |out, cookie|
+      cookie_jar.cookies.each do |cookie|
         hash[cookie.name] = cookie.value
       end
 
@@ -43,7 +49,7 @@ module RestClient
 
       jar = HTTP::CookieJar.new
       headers.fetch(:set_cookie, []).each do |cookie|
-        jar.parse(cookie, @args.fetch(:url))
+        jar.parse(cookie, @request.url)
       end
 
       @cookie_jar = jar
@@ -85,7 +91,7 @@ module RestClient
 
       url = headers[:location]
       if url !~ /^http/
-        url = URI.parse(args[:url]).merge(url).to_s
+        url = URI.parse(request.url).merge(url).to_s
       end
       new_args[:url] = url
       if request

--- a/lib/restclient/abstract_response.rb
+++ b/lib/restclient/abstract_response.rb
@@ -1,4 +1,5 @@
 require 'cgi'
+require 'http-cookie'
 
 module RestClient
 
@@ -24,9 +25,28 @@ module RestClient
 
     # Hash of cookies extracted from response headers
     def cookies
-      @cookies ||= (self.headers[:set_cookie] || {}).inject({}) do |out, cookie_content|
-        out.merge parse_cookie(cookie_content)
+      hash = {}
+
+      cookie_jar.cookies.each do |out, cookie|
+        hash[cookie.name] = cookie.value
       end
+
+      hash
+    end
+
+    # Cookie jar extracted from response headers.
+    #
+    # @return [HTTP::CookieJar]
+    #
+    def cookie_jar
+      return @cookie_jar if @cookie_jar
+
+      jar = HTTP::CookieJar.new
+      headers.fetch(:set_cookie, []).each do |cookie|
+        jar.parse(cookie, @args.fetch(:url))
+      end
+
+      @cookie_jar = jar
     end
 
     # Return the default behavior corresponding to the response code:
@@ -61,25 +81,28 @@ module RestClient
 
     # Follow a redirection
     def follow_redirection request = nil, result = nil, & block
+      new_args = @args.dup
+
       url = headers[:location]
       if url !~ /^http/
         url = URI.parse(args[:url]).merge(url).to_s
       end
-      args[:url] = url
+      new_args[:url] = url
       if request
         if request.max_redirects == 0
           raise MaxRedirectsReached
         end
-        args[:password] = request.password
-        args[:user] = request.user
-        args[:headers] = request.headers
-        args[:max_redirects] = request.max_redirects - 1
-        # pass any cookie set in the result
-        if result && result['set-cookie']
-          args[:headers][:cookies] = (args[:headers][:cookies] || {}).merge(parse_cookie(result['set-cookie']))
-        end
+        new_args[:password] = request.password
+        new_args[:user] = request.user
+        new_args[:headers] = request.headers
+        new_args[:max_redirects] = request.max_redirects - 1
+
+        # TODO: figure out what to do with original :cookie, :cookies values
+        new_args[:headers]['Cookie'] = HTTP::Cookie.cookie_value(
+          cookie_jar.cookies(new_args.fetch(:url)))
       end
-      Request.execute args, &block
+
+      Request.execute(new_args, &block)
     end
 
     def self.beautify_headers(headers)

--- a/lib/restclient/exceptions.rb
+++ b/lib/restclient/exceptions.rb
@@ -195,8 +195,8 @@ module RestClient
   end
 end
 
-# backwards compatibility
 class RestClient::Request
+  # backwards compatibility
   Redirect = RestClient::Redirect
   Unauthorized = RestClient::Unauthorized
   RequestFailed = RestClient::RequestFailed

--- a/lib/restclient/platform.rb
+++ b/lib/restclient/platform.rb
@@ -4,7 +4,7 @@ module RestClient
     # be false for jruby even on OS X.
     #
     # @return [Boolean]
-    def self.mac?
+    def self.mac_mri?
       RUBY_PLATFORM.include?('darwin')
     end
 

--- a/lib/restclient/raw_response.rb
+++ b/lib/restclient/raw_response.rb
@@ -13,12 +13,13 @@ module RestClient
 
     include AbstractResponse
 
-    attr_reader :file
+    attr_reader :file, :request
 
-    def initialize tempfile, net_http_res, args
+    def initialize(tempfile, net_http_res, args, request)
       @net_http_res = net_http_res
       @args = args
       @file = tempfile
+      @request = request
     end
 
     def to_s

--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -334,7 +334,7 @@ module RestClient
 
     def print_verify_callback_warnings
       warned = false
-      if RestClient::Platform.mac?
+      if RestClient::Platform.mac_mri?
         warn('warning: ssl_verify_callback return code is ignored on OS X')
         warned = true
       end

--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -544,8 +544,7 @@ module RestClient
           key = key.to_s.split(/_/).map { |w| w.capitalize }.join('-')
         end
         if 'CONTENT-TYPE' == key.upcase
-          target_value = value.to_s
-          result[key] = MIME::Types.type_for_extension target_value
+          result[key] = maybe_convert_extension(value.to_s)
         elsif 'ACCEPT' == key.upcase
           # Accept can be composed of several comma-separated values
           if value.is_a? Array
@@ -553,7 +552,9 @@ module RestClient
           else
             target_values = value.to_s.split ','
           end
-          result[key] = target_values.map { |ext| MIME::Types.type_for_extension(ext.to_s.strip) }.join(', ')
+          result[key] = target_values.map { |ext|
+            maybe_convert_extension(ext.to_s.strip)
+          }.join(', ')
         else
           result[key] = value.to_s
         end
@@ -571,21 +572,38 @@ module RestClient
       URI.const_defined?(:Parser) ? URI::Parser.new : URI
     end
 
-  end
-end
+    # Given a MIME type or file extension, return either a MIME type or, if
+    # none is found, the input unchanged.
+    #
+    #     >> maybe_convert_extension('json')
+    #     => 'application/json'
+    #
+    #     >> maybe_convert_extension('unknown')
+    #     => 'unknown'
+    #
+    #     >> maybe_convert_extension('application/xml')
+    #     => 'application/xml'
+    #
+    # @param ext [String]
+    #
+    # @return [String]
+    #
+    def maybe_convert_extension(ext)
+      unless ext =~ /\A[a-zA-Z0-9_@-]+\z/
+        # Don't look up strings unless they look like they could be a file
+        # extension known to mime-types.
+        #
+        # There currently isn't any API public way to look up extensions
+        # directly out of MIME::Types, but the type_for() method only strips
+        # off after a period anyway.
+        return ext
+      end
 
-module MIME
-  class Types
-
-    # Return the first found content-type for a value considered as an extension or the value itself
-    def type_for_extension ext
-      candidates = @extension_index[ext]
-      candidates.empty? ? ext : candidates[0].content_type
-    end
-
-    class << self
-      def type_for_extension ext
-        @__types__.type_for_extension ext
+      types = MIME::Types.type_for(ext)
+      if types.empty?
+        ext
+      else
+        types.first.content_type
       end
     end
   end

--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -484,9 +484,9 @@ module RestClient
     def process_result res, & block
       if @raw_response
         # We don't decode raw requests
-        response = RawResponse.new(@tf, res, args)
+        response = RawResponse.new(@tf, res, args, self)
       else
-        response = Response.create(Request.decode(res['content-encoding'], res.body), res, args)
+        response = Response.create(Request.decode(res['content-encoding'], res.body), res, args, self)
       end
 
       if block_given?

--- a/lib/restclient/response.rb
+++ b/lib/restclient/response.rb
@@ -6,17 +6,14 @@ module RestClient
 
     include AbstractResponse
 
-    attr_accessor :args, :net_http_res
-
     def body
       self
     end
 
-    def self.create body, net_http_res, args
+    def self.create body, net_http_res, args, request
       result = body || ''
       result.extend Response
-      result.net_http_res = net_http_res
-      result.args = args
+      result.response_set_vars(net_http_res, args, request)
       result
     end
 

--- a/lib/restclient/version.rb
+++ b/lib/restclient/version.rb
@@ -1,5 +1,5 @@
 module RestClient
-  VERSION = '1.8.0.rc1' unless defined?(self::VERSION)
+  VERSION = '1.8.0' unless defined?(self::VERSION)
 
   def self.version
     VERSION

--- a/lib/restclient/version.rb
+++ b/lib/restclient/version.rb
@@ -1,5 +1,5 @@
 module RestClient
-  VERSION = '1.7.2' unless defined?(self::VERSION)
+  VERSION = '1.7.3' unless defined?(self::VERSION)
 
   def self.version
     VERSION

--- a/lib/restclient/version.rb
+++ b/lib/restclient/version.rb
@@ -1,5 +1,5 @@
 module RestClient
-  VERSION = '1.7.3' unless defined?(self::VERSION)
+  VERSION = '1.8.0.rc1' unless defined?(self::VERSION)
 
   def self.version
     VERSION

--- a/rest-client.gemspec
+++ b/rest-client.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('pry-doc')
   s.add_development_dependency('rdoc', '>= 2.4.2', '< 5.0')
 
+  s.add_dependency('http-cookie', '>= 1.0.2', '< 2.0')
   s.add_dependency('mime-types', '>= 1.16', '< 3.0')
   s.add_dependency('netrc', '~> 0.7')
 

--- a/spec/integration/request_spec.rb
+++ b/spec/integration/request_spec.rb
@@ -34,7 +34,7 @@ describe RestClient::Request do
     #
     # On OS X, this test fails since Apple has patched OpenSSL to always fall
     # back on the system CA store.
-    it "is unsuccessful with an incorrect ca_file", :unless => RestClient::Platform.mac? do
+    it "is unsuccessful with an incorrect ca_file", :unless => RestClient::Platform.mac_mri? do
       request = RestClient::Request.new(
         :method => :get,
         :url => 'https://www.mozilla.org',
@@ -45,7 +45,7 @@ describe RestClient::Request do
 
     # On OS X, this test fails since Apple has patched OpenSSL to always fall
     # back on the system CA store.
-    it "is unsuccessful with an incorrect ca_path", :unless => RestClient::Platform.mac? do
+    it "is unsuccessful with an incorrect ca_path", :unless => RestClient::Platform.mac_mri? do
       request = RestClient::Request.new(
         :method => :get,
         :url => 'https://www.mozilla.org',
@@ -79,7 +79,7 @@ describe RestClient::Request do
     end
 
     it "fails verification when the callback returns false",
-       :unless => RestClient::Platform.mac? do
+       :unless => RestClient::Platform.mac_mri? do
       request = RestClient::Request.new(
         :method => :get,
         :url => 'https://www.mozilla.org',
@@ -90,7 +90,7 @@ describe RestClient::Request do
     end
 
     it "succeeds verification when the callback returns true",
-       :unless => RestClient::Platform.mac? do
+       :unless => RestClient::Platform.mac_mri? do
       request = RestClient::Request.new(
         :method => :get,
         :url => 'https://www.mozilla.org',

--- a/spec/unit/abstract_response_spec.rb
+++ b/spec/unit/abstract_response_spec.rb
@@ -8,16 +8,18 @@ describe RestClient::AbstractResponse do
 
     attr_accessor :size
 
-    def initialize net_http_res, args
+    def initialize net_http_res, args, request
       @net_http_res = net_http_res
       @args = args
+      @request = request
     end
 
   end
 
   before do
     @net_http_res = double('net http response')
-    @response = MyAbstractResponse.new(@net_http_res, {})
+    @request = double('restclient request', :url => 'http://example.com')
+    @response = MyAbstractResponse.new(@net_http_res, {}, @request)
   end
 
   it "fetches the numeric response code" do
@@ -53,7 +55,8 @@ describe RestClient::AbstractResponse do
 
   it "extract strange cookies" do
     @net_http_res.should_receive(:to_hash).and_return('set-cookie' => ['session_id=ZJ/HQVH6YE+rVkTpn0zvTQ==; path=/'])
-    @response.cookies.should eq({ 'session_id' => 'ZJ%2FHQVH6YE+rVkTpn0zvTQ%3D%3D' })
+    @response.headers.should eq({:set_cookie => ['session_id=ZJ/HQVH6YE+rVkTpn0zvTQ==; path=/']})
+    @response.cookies.should eq({ 'session_id' => 'ZJ/HQVH6YE+rVkTpn0zvTQ==' })
   end
 
   it "doesn't escape cookies" do

--- a/spec/unit/raw_response_spec.rb
+++ b/spec/unit/raw_response_spec.rb
@@ -4,7 +4,8 @@ describe RestClient::RawResponse do
   before do
     @tf = double("Tempfile", :read => "the answer is 42", :open => true)
     @net_http_res = double('net http response')
-    @response = RestClient::RawResponse.new(@tf, @net_http_res, {})
+    @request = double('http request')
+    @response = RestClient::RawResponse.new(@tf, @net_http_res, {}, @request)
   end
 
   it "behaves like string" do

--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -417,13 +417,13 @@ describe RestClient::Request do
 
     it 'does not log request password' do
       log = RestClient.log = []
-      RestClient::Request.new(:method => :get, :url => 'http://user:password@url', :headers => {:user_agent => 'rest-client'}).log_request
+      RestClient::Request.new(:method => :get, :url => 'http://user:password@url', :headers => {:user_agent => 'rest-client', :accept => '*/*'}).log_request
       log[0].should eq %Q{RestClient.get "http://user:REDACTED@url", "Accept"=>"*/*", "Accept-Encoding"=>"gzip, deflate", "User-Agent"=>"rest-client"\n}
     end
 
     it 'logs invalid URIs, even though they will fail elsewhere' do
       log = RestClient.log = []
-      RestClient::Request.new(:method => :get, :url => 'http://a@b:c', :headers => {:user_agent => 'rest-client'}).log_request
+      RestClient::Request.new(:method => :get, :url => 'http://a@b:c', :headers => {:user_agent => 'rest-client', :accept => '*/*'}).log_request
       log[0].should eq %Q{RestClient.get "[invalid uri]", "Accept"=>"*/*", "Accept-Encoding"=>"gzip, deflate", "User-Agent"=>"rest-client"\n}
     end
   end

--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -414,6 +414,18 @@ describe RestClient::Request do
       @request.log_response res
       log[0].should eq "# => 200 OK | text/html 0 bytes\n"
     end
+
+    it 'does not log request password' do
+      log = RestClient.log = []
+      RestClient::Request.new(:method => :get, :url => 'http://user:password@url', :headers => {:user_agent => 'rest-client'}).log_request
+      log[0].should eq %Q{RestClient.get "http://user:REDACTED@url", "Accept"=>"*/*", "Accept-Encoding"=>"gzip, deflate", "User-Agent"=>"rest-client"\n}
+    end
+
+    it 'logs invalid URIs, even though they will fail elsewhere' do
+      log = RestClient.log = []
+      RestClient::Request.new(:method => :get, :url => 'http://a@b:c', :headers => {:user_agent => 'rest-client'}).log_request
+      log[0].should eq %Q{RestClient.get "[invalid uri]", "Accept"=>"*/*", "Accept-Encoding"=>"gzip, deflate", "User-Agent"=>"rest-client"\n}
+    end
   end
 
   it "strips the charset from the response content type" do

--- a/spec/unit/restclient_spec.rb
+++ b/spec/unit/restclient_spec.rb
@@ -71,9 +71,9 @@ describe RestClient do
   end
 
   describe 'version' do
-    it 'has a version ~> 1.7.0.alpha' do
+    it 'has a version ~> 1.8.0.alpha' do
       ver = Gem::Version.new(RestClient.version)
-      Gem::Requirement.new('~> 1.7.0.alpha').should be_satisfied_by(ver)
+      Gem::Requirement.new('~> 1.8.0.alpha').should be_satisfied_by(ver)
     end
   end
 end


### PR DESCRIPTION
This fork of rest client had the following issues:

```
Version: 1.7.2
Advisory: CVE-2015-1820
Criticality: Unknown
URL: https://github.com/rest-client/rest-client/issues/369
Title: rubygem-rest-client: session fixation vulnerability via Set-Cookie header
s in 30x redirection responses
Solution: upgrade to >= 1.8.0
```

```
Version: 1.7.2
Advisory: CVE-2015-3448
Criticality: Unknown
URL: http://www.osvdb.org/show/osvdb/117461
Title: Rest-Client Gem for Ruby logs password information in plaintext
Solution: upgrade to >= 1.7.3
```

@marcduez I haven't looked closely at the Wealthsimple changes to our `rest-client` fork, are all changes intact after this merge?
